### PR TITLE
Push position of point to buffer-undo-list

### DIFF
--- a/php-refactor-mode.el
+++ b/php-refactor-mode.el
@@ -128,6 +128,7 @@ ARGS contains a list of all the arguments required for the specific method to ru
   (save-buffer)
   (let ((revert-buffer-function 'php-refactor--revert-buffer-keep-history)
         (temp-point (point)))
+    (setq buffer-undo-list (cons temp-point buffer-undo-list))
     (shell-command
      (php-refactor--generate-command args))
     (revert-buffer nil t t)


### PR DESCRIPTION
This small change pushes the position of point (before doing the refactoring) to the current undo history group, so the point is put to the correct position on undo (instead of always moving it to the beginning of the buffer)

This closes #2 